### PR TITLE
Fix 5beam Levelpacks

### DIFF
--- a/5b.js
+++ b/5b.js
@@ -7621,7 +7621,7 @@ function setup() {
 		fetch('https://5beam.zelo.dev/api/levelpack?levels=1&id=' + levelpackId, {method: 'GET'})
 			.then(async (res) => {
 				exploreLevelPageLevel = await res.json();
-				if (levelpackProgress[exploreLevelPageLevel.id] === 'undefined') playExploreLevel();
+				if (levelpackProgress[exploreLevelPageLevel.id] === undefined) playExploreLevel();
 				else continueExploreLevelpack();
 				rAF60fps();
 			})


### PR DESCRIPTION
While this does fix levelpack loading, it may be best to... examine other areas where 'undefined' is used. There are probably other bugs in those places too since `undefined` is not generally a string (unless that's how it's used in HTML5b).