### PR TITLE
5beam: Pass token using authorization header instead of third-party cookies

### DIFF
--- a/5b.js
+++ b/5b.js
@@ -10210,6 +10210,10 @@ function requestError() {
 	requestsWaiting--;
 }
 
+function getAuthHeader() {
+	return {'Authorization': 'pb_auth=' + localStorage.getItem('5beam_auth')};
+}
+
 function getExplorePage(p, t, s) {
 	requestAdded();
 	return fetch('https://5beam.zelo.dev/api/page?page=' + p + '&sort=' + s + '&type=' + t, {method: 'GET'})
@@ -10288,7 +10292,7 @@ function getExploreUser(id) {
 
 function getCurrentExploreUserID() {
 	// from zelo: despite the pb_auth cookie having this information, we cannot use it as it is httpOnly
-	return fetch("https://5beam.zelo.dev/api/profile", {method: "GET", credentials: "include"})
+	return fetch("https://5beam.zelo.dev/api/profile", {method: "GET", headers: getAuthHeader()})
 		.then(async response => {
 			loggedInExploreUser5beamID = (await response.json()).id;
 			localStorage.setItem("5beam_id", loggedInExploreUser5beamID);
@@ -10333,7 +10337,8 @@ function logInExplore() {
 
 function logOutExplore() {
 	loggedInExploreUser5beamID = -1;
-	fetch("https://5beam.zelo.dev/logout", {method: "POST", credentials: "include"});
+	localStorage.removeItem('5beam_auth');
+	localStorage.removeItem('5beam_id');
 }
 
 async function postExploreLevelOrPack(title, desc, data, isLevelpack=false) {
@@ -10352,7 +10357,7 @@ async function postExploreLevelOrPack(title, desc, data, isLevelpack=false) {
 		modded: ''
 	}
 
-	return fetch('https://5beam.zelo.dev/api/create/' + (isLevelpack?'levelpack':'level'), {method: 'POST', credentials: "include", body: JSON.stringify(body)})
+	return fetch('https://5beam.zelo.dev/api/create/' + (isLevelpack?'levelpack':'level'), {method: 'POST', headers: getAuthHeader(), body: JSON.stringify(body)})
 		.then(response => {
 			// requestResolved();
 			if (response.status == 200) {
@@ -10380,7 +10385,7 @@ async function postExploreModifyLevel(id, title, desc, difficulty, file) {
 	}
 	if (file != '') body.file = file;
 
-	return fetch('https://5beam.zelo.dev/api/modify/level?id=' + id, {method: 'POST', credentials: "include", body: JSON.stringify(body)})
+	return fetch('https://5beam.zelo.dev/api/modify/level?id=' + id, {method: 'POST', headers: getAuthHeader(), body: JSON.stringify(body)})
 		.then(response => {
 			requestResolved();
 			if (response.status == 200) {

--- a/authredirect.html
+++ b/authredirect.html
@@ -4,8 +4,15 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Discord Auth Redirect</title>
+	<script type="text/javascript">
+		function saveTokens() {
+			const params = new URLSearchParams(window.location.search);
+			localStorage.setItem('5beam_auth', params.get('5beam_auth'));
+			window.close();
+		}
+	</script>
 </head>
-<body onload="window.close()">
+<body onload="saveTokens()">
 	<p>If this window doesn't close automatically, you can just close it yourself.</p>
 </body>
 </html>


### PR DESCRIPTION
third-party cookies have a high chance of being blocked due to privacy settings / enterprise (school laptops :P) so i'm switching back to using local storage